### PR TITLE
recorder: no longer require enumerated features/actions/metadata keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/telemetry",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Sourcegraph client telemetry v2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,13 +10,6 @@ import {
 
 const telemetrySource: TelemetrySource = { client: "test" };
 
-type Feature = "fooBar" | "barBaz";
-
-enum Action {
-  View = "view",
-  Error = "error",
-}
-
 type MetadataKey = "foo" | "bar";
 
 enum BillingProducts {
@@ -28,12 +21,17 @@ enum BillingCategories {
 }
 
 class ExampleTelemetryProvider extends TelemetryRecorderProvider<
-  Feature,
-  Action,
-  MetadataKey,
   BillingProducts,
   BillingCategories
 > {}
+
+type StringObject = {
+  key: string;
+};
+
+type EnumObject = {
+  key: "foo" | "bar";
+};
 
 describe("EventRecorderProvider", () => {
   test("should buffer events", async () => {
@@ -50,26 +48,45 @@ describe("EventRecorderProvider", () => {
     );
     const recorder = provider.getRecorder();
 
-    recorder.recordEvent("fooBar", Action.View);
-    recorder.recordEvent("barBaz", Action.Error, {
+    // ✅ const string
+    const constString = "asdfasdf";
+    recorder.recordEvent(constString, "view");
+
+    // ❌ variable string
+    const varString: string = "asdf";
+    recorder.recordEvent(varString, "error");
+
+    // ✅ string literals
+    const varMetadataKey: string = "asdf";
+    recorder.recordEvent("foobar", "asdfafsd", {
       metadata: {
         foo: 12,
         bar: 13,
         // Disallowed
-        // unknown: 13,
-        // 'alsoKnown': 12,
+        [varMetadataKey]: 12,
       },
     });
+
+    // ❌ string var
+    recorder.recordEvent("fooBar" as string, "view");
+
+    // ❌ type Object = { key: string };
+    const stringObject: StringObject = { key: "foo" };
+    recorder.recordEvent(stringObject.key, "asdf");
+
+    // ✅ type EnumObject = { key: "foo" | "bar" };
+    const enumObject: EnumObject = { key: "foo" };
+    recorder.recordEvent(enumObject.key, "asdf");
 
     // Is buffered
     expect(exporter.getExported().length).toBe(0);
 
     // Buffer is flushed
     provider.unsubscribe();
-    expect(exporter.getExported().length).toBe(2);
+    expect(exporter.getExported().length).toBe(3);
 
     // After close, we still receive events as a fallback, after a brief time
-    recorder.recordEvent("fooBar", Action.View);
+    recorder.recordEvent("fooBar", "view");
     await new Promise((resolve) =>
       setTimeout(() => {
         resolve(expect(exporter.getExported().length).toBe(3));
@@ -80,8 +97,6 @@ describe("EventRecorderProvider", () => {
   test("can disable buffering of events", () => {
     const exporter = new TestTelemetryExporter();
     const provider = new TelemetryRecorderProvider<
-      Feature,
-      Action,
       MetadataKey,
       BillingProducts,
       BillingCategories
@@ -97,9 +112,9 @@ describe("EventRecorderProvider", () => {
     const recorder = provider.getRecorder();
 
     // Records should be immediately available
-    recorder.recordEvent("fooBar", Action.View);
+    recorder.recordEvent("fooBar", "view");
     expect(exporter.getExported().length).toBe(1);
-    recorder.recordEvent("barBaz", Action.Error, {
+    recorder.recordEvent("barBaz", "error", {
       version: 0,
       metadata: { foo: 12 },
     });
@@ -114,8 +129,6 @@ describe("EventRecorderProvider", () => {
     };
     const processed: TelemetryEventInput[] = [];
     const provider = new TelemetryRecorderProvider<
-      Feature,
-      Action,
       MetadataKey,
       BillingProducts,
       BillingCategories
@@ -135,8 +148,8 @@ describe("EventRecorderProvider", () => {
     );
     const recorder = provider.getRecorder();
 
-    recorder.recordEvent("fooBar", Action.View);
-    recorder.recordEvent("barBaz", Action.Error, {
+    recorder.recordEvent("fooBar", "view");
+    recorder.recordEvent("barBaz", "error", {
       version: 0,
       metadata: { foo: 12 },
       privateMetadata: {},
@@ -158,7 +171,7 @@ describe("EventRecorderProvider", () => {
       category: BillingCategories.B,
       product: BillingProducts.A,
     };
-    recorder.recordEvent("fooBar", Action.Error, {
+    recorder.recordEvent("fooBar", "error", {
       version: 0,
       billingMetadata: customBillingMetadata,
     });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,8 +10,6 @@ import {
 
 const telemetrySource: TelemetrySource = { client: "test" };
 
-type MetadataKey = "foo" | "bar";
-
 enum BillingProducts {
   A = "A",
 }
@@ -24,10 +22,6 @@ class ExampleTelemetryProvider extends TelemetryRecorderProvider<
   BillingProducts,
   BillingCategories
 > {}
-
-type StringObject = {
-  key: string;
-};
 
 type EnumObject = {
   key: "foo" | "bar";
@@ -53,26 +47,25 @@ describe("EventRecorderProvider", () => {
     recorder.recordEvent(constString, "view");
 
     // ❌ variable string
-    const varString: string = "asdf";
-    recorder.recordEvent(varString, "error");
+    // const varString: string = "asdf";
+    // recorder.recordEvent(varString, "error");
 
     // ✅ string literals
-    const varMetadataKey: string = "asdf";
     recorder.recordEvent("foobar", "asdfafsd", {
       metadata: {
         foo: 12,
         bar: 13,
         // Disallowed
-        [varMetadataKey]: 12,
+        // ["asdf" as string]: 12,
       },
     });
 
     // ❌ string var
-    recorder.recordEvent("fooBar" as string, "view");
+    // recorder.recordEvent("fooBar" as string, "view");
 
-    // ❌ type Object = { key: string };
-    const stringObject: StringObject = { key: "foo" };
-    recorder.recordEvent(stringObject.key, "asdf");
+    // ❌ type StringObject = { key: string };
+    // const stringObject: StringObject = { key: "foo" };
+    // recorder.recordEvent(stringObject.key, "asdf");
 
     // ✅ type EnumObject = { key: "foo" | "bar" };
     const enumObject: EnumObject = { key: "foo" };
@@ -89,7 +82,7 @@ describe("EventRecorderProvider", () => {
     recorder.recordEvent("fooBar", "view");
     await new Promise((resolve) =>
       setTimeout(() => {
-        resolve(expect(exporter.getExported().length).toBe(3));
+        resolve(expect(exporter.getExported().length).toBe(4));
       }, 5)
     );
   });
@@ -97,7 +90,6 @@ describe("EventRecorderProvider", () => {
   test("can disable buffering of events", () => {
     const exporter = new TestTelemetryExporter();
     const provider = new TelemetryRecorderProvider<
-      MetadataKey,
       BillingProducts,
       BillingCategories
     >(
@@ -129,7 +121,6 @@ describe("EventRecorderProvider", () => {
     };
     const processed: TelemetryEventInput[] = [];
     const provider = new TelemetryRecorderProvider<
-      MetadataKey,
       BillingProducts,
       BillingCategories
     >(

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,20 +21,20 @@ export * from "./api";
  * This effectively requires T to NOT be an arbitrary string - it must be
  * a string value known ahead of time.
  */
-type KnownString<T extends string> = string extends T
+type KnownString<Value extends string> = string extends Value
   ? "INPUT TYPE ERROR: string type is too broad, should be a known value"
-  : T;
+  : Value;
 
 /**
  * KnownKeys enforces that:
  *
- * - T must be an object with string keys (KeyT) and number values
+ * - Key must be an object with string keys (Key) and number values
  * - an object with arbitary strings as keys must NOT be a T
  *
- * This effectively requires KeyT to NOT be an arbitrary string - keys must be
+ * This effectively requires Key to NOT be an arbitrary string - keys must be
  * known ahead of time.
  */
-type KnownKeys<KeyT extends string, T extends { [key in KeyT]: number }> = {
+type KnownKeys<Key extends string, T extends { [key in Key]: number }> = {
   [key: string]: number;
 } extends T
   ? {
@@ -55,8 +55,8 @@ type KnownKeys<KeyT extends string, T extends { [key in KeyT]: number }> = {
  * type.
  */
 export interface TelemetryRecorder<
-  BillingProductsT extends string,
-  BillingCategoriesT extends string
+  BillingProducts extends string,
+  BillingCategories extends string
 > {
   /**
    * Record a telemetry event.
@@ -76,16 +76,16 @@ export interface TelemetryRecorder<
    * To learn more, see https://docs.sourcegraph.com/dev/background-information/telemetry
    */
   recordEvent<
-    FeatureT extends string,
-    ActionT extends string,
-    MetadataKeyT extends string
+    Feature extends string,
+    Action extends string,
+    MetadataKey extends string
   >(
-    feature: KnownString<FeatureT>,
-    action: KnownString<ActionT>,
+    feature: KnownString<Feature>,
+    action: KnownString<Action>,
     parameters?: TelemetryEventParameters<
-      KnownKeys<MetadataKeyT, { [key in MetadataKeyT]: number }>,
-      BillingProductsT,
-      BillingCategoriesT
+      KnownKeys<MetadataKey, { [key in MetadataKey]: number }>,
+      BillingProducts,
+      BillingCategories
     >
   ): void;
 }
@@ -137,8 +137,8 @@ export type TelemetrySource = {
  * exporter. Additional processors can be stacked on top as well.
  */
 export class TelemetryRecorderProvider<
-  BillingProductsT extends string,
-  BillingCategoriesT extends string
+  BillingProducts extends string,
+  BillingCategories extends string
 > {
   private submitter: TelemetrySubmitter;
 
@@ -161,7 +161,7 @@ export class TelemetryRecorderProvider<
    */
   getRecorder(
     additionalProcessors?: TelemetryProcessor[]
-  ): TelemetryRecorder<BillingProductsT, BillingCategoriesT> {
+  ): TelemetryRecorder<BillingProducts, BillingCategories> {
     return new EventRecorder(
       this.source,
       this.submitter,
@@ -186,9 +186,9 @@ export class TelemetryRecorderProvider<
  * TelemetryEventParameters describes additional, optional parameters for recording events.
  */
 export type TelemetryEventParameters<
-  MetadataT extends { [key: string]: number },
-  BillingProductsT extends string,
-  BillingCategoriesT extends string
+  Metadata extends { [key: string]: number },
+  BillingProducts extends string,
+  BillingCategories extends string
 > = {
   /**
    * version should indicate the version of the shape of this particular
@@ -209,7 +209,7 @@ export type TelemetryEventParameters<
    * the value space into a known set, where values can be represented using
    * a numeric identifier.
    */
-  metadata?: MetadataT;
+  metadata?: Metadata;
   /**
    * privateMetadata is an arbitrary value. This is NOT exported by default, as
    * its arbitrary shape allows for sensitive data we should not export by default.
@@ -233,12 +233,12 @@ export type TelemetryEventParameters<
     /**
      * Billing product ID associated with the event.
      */
-    product: BillingProductsT;
+    product: BillingProducts;
 
     /**
      * Billing category ID the event falls into.
      */
-    category: BillingCategoriesT;
+    category: BillingCategories;
   };
 };
 
@@ -331,12 +331,12 @@ class EventRecorder<
   /**
    * BillingProductsT enumerates known billing product names.
    */
-  BillingProductsT extends string,
+  BillingProducts extends string,
   /**
    * BillingCategoriesT enumerates known billing category names.
    */
-  BillingCategoriesT extends string
-> implements TelemetryRecorder<BillingProductsT, BillingCategoriesT>
+  BillingCategories extends string
+> implements TelemetryRecorder<BillingProducts, BillingCategories>
 {
   constructor(
     private source: TelemetrySource,
@@ -348,16 +348,16 @@ class EventRecorder<
    * Record an event.
    */
   recordEvent<
-    FeatureT extends string,
-    ActionT extends string,
-    MetadataKeyT extends string
+    Feature extends string,
+    Action extends string,
+    MetadataKey extends string
   >(
-    feature: KnownString<FeatureT>,
-    action: KnownString<ActionT>,
+    feature: KnownString<Feature>,
+    action: KnownString<Action>,
     parameters?: TelemetryEventParameters<
-      KnownKeys<MetadataKeyT, { [key in MetadataKeyT]: number }>,
-      BillingProductsT,
-      BillingCategoriesT
+      KnownKeys<MetadataKey, { [key in MetadataKey]: number }>,
+      BillingProducts,
+      BillingCategories
     >
   ): void {
     let apiEvent = {


### PR DESCRIPTION
As adoption in VSCode progresses, the need to enumerate known  features/actions/metadata keys has proven problematic, i.e.

```ts
type Feature = 'feature1' | 'feature2' | ...
```

These are already growing unmanageable, and having to go back and forth to the definition to add events is quite a pain.

Enter some StackOverflow hackery I found: by performing a type assertion that generalized string types be prohibited, we can make it so that arbitrary strings can't be used, but allow string _literals_, i.e.

```ts
/**
 * KnownString enforces that:
 *
 * - T must be a string
 * - string must NOT be a T
 *
 * This effectively requires T to NOT be an arbitrary string - it must be
 * a string value known ahead of time.
 */
type KnownString<T extends string> = string extends T
  ? "INPUT TYPE ERROR: string type is too broad, should be a known value"
  : T;
```

Using this on `feature` and `action` is easy, and we get type errors like:

<img width="903" alt="image" src="https://github.com/sourcegraph/telemetry/assets/23356519/7cedd01d-86d6-4460-8514-9e8a094489ec">

because the failure case on the type resolves to an unrealistic "key". A broader set of examples:

<img width="469" alt="image" src="https://github.com/sourcegraph/telemetry/assets/23356519/15e4916a-4558-4e4d-9fd4-00231e91c325">

For metadata keys, we apply a similar hack over `{ [key:string]: number }`:

<img width="724" alt="image" src="https://github.com/sourcegraph/telemetry/assets/23356519/bc8b4a21-1c2b-4c5b-a3cb-fcd560000379">
