### PR TITLE
telemetry: add interactionID to parameter

### DIFF
--- a/schema/telemetry.graphql
+++ b/schema/telemetry.graphql
@@ -30,6 +30,9 @@ input TelemetryEventInput {
 
   """
   Optional marketing campaign tracking parameters.
+
+  🚨 SECURITY: This metadata is NEVER exported from private Sourcegraph instances,
+  and is only exported for events tracked in the public Sourcegraph.com instance.
   """
   marketingTracking: TelemetryEventMarketingTrackingInput
 }
@@ -39,9 +42,7 @@ Properties comprising the source of a telemetry V2 event reported by a client.
 """
 input TelemetryEventSourceInput {
   """
-  Source client of the event. Clients must come from a static set of predefined
-  metadata keys in libraries - it is left as a string in the API to allow some
-  backwards/forwards flexibility.
+  Source client of the event.
   """
   client: String!
   """
@@ -67,13 +68,23 @@ input TelemetryEventParametersInput {
   Private metadata in JSON format. Unlike metadata, values can be of any type,
   not just numeric.
 
-  By default, this metadata is assumed to be unsafe for export from an instance.
+  🚨 SECURITY: This metadata is NOT exported from instances by default, as it
+  can contain arbitrarily-shaped data that may accidentally contain sensitive
+  or private contents.
   """
   privateMetadata: JSONValue
   """
   Billing-related metadata.
   """
   billingMetadata: TelemetryEventBillingMetadataInput
+  """
+  Optional interaction ID that can be provided to indicate the interaction
+  this event belongs to. It overrides the X-Sourcegraph-Interaction-ID header
+  if one is set on the request recording the event.
+
+  This parameter is only available in Sourcegraph 5.2.4 and later.
+  """
+  interactionID: String
 }
 
 """
@@ -81,14 +92,18 @@ A single, PII-free metadata item for telemetry V2 events.
 """
 input TelemetryEventMetadataInput {
   """
-  Metadata keys must come from a static set of predefined metadata keys in
-  libraries - it is left as a string in the API to allow some flexibility.
+  The key identifying this metadata entry.
   """
   key: String!
   """
-  Numeric value associated with the key.
+  Numeric value associated with the key. Enforcing numeric values eliminates
+  risks of accidentally shipping sensitive or private data.
+
+  The value type in the schema is JSONValue for flexibility, but we ONLY
+  accept numeric values (integers and floats) - any other value will be
+  rejected.
   """
-  value: Int!
+  value: JSONValue!
 }
 
 """
@@ -114,7 +129,8 @@ input TelemetryEventBillingMetadataInput {
 """
 Marketing campaign tracking parameters for a telemetry V2 event.
 
-By default, this metadata is assumed to be unsafe for export from an instance.
+🚨 SECURITY: This metadata is NEVER exported from private Sourcegraph instances,
+and is only exported for events tracked in the public Sourcegraph.com instance.
 """
 input TelemetryEventMarketingTrackingInput {
   """

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -57,7 +57,12 @@ export type TelemetryEventInput = {
    * left as a string in the API to allow some flexibility.
    */
   feature: Scalars['String']['input'];
-  /** Optional marketing campaign tracking parameters. */
+  /**
+   * Optional marketing campaign tracking parameters.
+   *
+   * 🚨 SECURITY: This metadata is NEVER exported from private Sourcegraph instances,
+   * and is only exported for events tracked in the public Sourcegraph.com instance.
+   */
   marketingTracking?: InputMaybe<TelemetryEventMarketingTrackingInput>;
   /** Parameters of the event. */
   parameters: TelemetryEventParametersInput;
@@ -68,7 +73,8 @@ export type TelemetryEventInput = {
 /**
  * Marketing campaign tracking parameters for a telemetry V2 event.
  *
- * By default, this metadata is assumed to be unsafe for export from an instance.
+ * 🚨 SECURITY: This metadata is NEVER exported from private Sourcegraph instances,
+ * and is only exported for events tracked in the public Sourcegraph.com instance.
  */
 export type TelemetryEventMarketingTrackingInput = {
   /** Cohort ID to identify the user as part of a specific A/B test. */
@@ -89,17 +95,42 @@ export type TelemetryEventMarketingTrackingInput = {
   url?: InputMaybe<Scalars['String']['input']>;
 };
 
+/** A single, PII-free metadata item for telemetry V2 events. */
+export type TelemetryEventMetadataInput = {
+  /** The key identifying this metadata entry. */
+  key: Scalars['String']['input'];
+  /**
+   * Numeric value associated with the key. Enforcing numeric values eliminates
+   * risks of accidentally shipping sensitive or private data.
+   *
+   * The value type in the schema is JSONValue for flexibility, but we ONLY
+   * accept numeric values (integers and floats) - any other value will be
+   * rejected.
+   */
+  value: Scalars['JSONValue']['input'];
+};
+
 /** Properties of a telemetry V2 event. */
 export type TelemetryEventParametersInput = {
   /** Billing-related metadata. */
   billingMetadata?: InputMaybe<TelemetryEventBillingMetadataInput>;
+  /**
+   * Optional interaction ID that can be provided to indicate the interaction
+   * this event belongs to. It overrides the X-Sourcegraph-Interaction-ID header
+   * if one is set on the request recording the event.
+   *
+   * This parameter is only available in Sourcegraph 5.2.4 and later.
+   */
+  interactionID?: InputMaybe<Scalars['String']['input']>;
   /** Strictly typed metadata that must not contain any sensitive data or PII. */
   metadata?: InputMaybe<Array<TelemetryEventMetadataInput>>;
   /**
    * Private metadata in JSON format. Unlike metadata, values can be of any type,
    * not just numeric.
    *
-   * By default, this metadata is assumed to be unsafe for export from an instance.
+   * 🚨 SECURITY: This metadata is NOT exported from instances by default, as it
+   * can contain arbitrarily-shaped data that may accidentally contain sensitive
+   * or private contents.
    */
   privateMetadata?: InputMaybe<Scalars['JSONValue']['input']>;
   /**
@@ -109,24 +140,9 @@ export type TelemetryEventParametersInput = {
   version: Scalars['Int']['input'];
 };
 
-/** A single, PII-free metadata item for telemetry V2 events. */
-export type TelemetryEventMetadataInput = {
-  /**
-   * Metadata keys must come from a static set of predefined metadata keys in
-   * libraries - it is left as a string in the API to allow some flexibility.
-   */
-  key: Scalars['String']['input'];
-  /** Numeric value associated with the key. */
-  value: Scalars['Int']['input'];
-};
-
 /** Properties comprising the source of a telemetry V2 event reported by a client. */
 export type TelemetryEventSourceInput = {
-  /**
-   * Source client of the event. Clients must come from a static set of predefined
-   * metadata keys in libraries - it is left as a string in the API to allow some
-   * backwards/forwards flexibility.
-   */
+  /** Source client of the event. */
   client: Scalars['String']['input'];
   /** Version of the source client of the event. */
   clientVersion?: InputMaybe<Scalars['String']['input']>;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -170,4 +170,28 @@ describe("EventRecorderProvider", () => {
       customBillingMetadata
     );
   });
+
+  test("interaction ID", () => {
+    const exporter = new TestTelemetryExporter();
+    const provider = new TelemetryRecorderProvider<
+      BillingProducts,
+      BillingCategories
+    >(
+      telemetrySource,
+      exporter,
+      undefined, // no processors
+      {
+        ...defaultEventRecordingOptions,
+        bufferTimeMs: 0, // disable buffering
+      }
+    );
+    const recorder = provider.getRecorder();
+
+    // Records should be immediately available
+    recorder.recordEvent("fooBar", "view", {
+      interactionID: "abcde",
+    });
+    expect(exporter.getExported().length).toBe(1);
+    expect(exporter.getExported()[0].parameters.interactionID).toEqual("abcde");
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,6 +201,12 @@ export type TelemetryEventParameters<
    */
   version?: number;
   /**
+   * interactionID can be used to multiple events together as under a single
+   * interaction. It can also be set using the X-Sourcegraph-Interaction-ID
+   * request header on all interactions with the Sourcegraph backend.
+   */
+  interactionID?: string;
+  /**
    * metadata is array of tuples with predefined keys and arbitrary
    * numeric value. This data is always exported alongside events to
    * Sourcegraph.
@@ -365,13 +371,14 @@ class EventRecorder<
       BillingCategories
     >
   ): void {
-    let apiEvent = {
+    const apiEvent: TelemetryEventInput = {
       feature,
       action,
       source: this.source,
       parameters: parameters
         ? {
             version: parameters.version || 0,
+            interactionID: parameters.interactionID,
             metadata: parameters.metadata
               ? Object.entries<number | undefined>(parameters.metadata).map(
                   ([key, value]): TelemetryEventMetadataInput => ({


### PR DESCRIPTION
Adds interaction ID for linking multiple events together as a first-class citizen - see https://github.com/sourcegraph/sourcegraph/pull/58016 and https://github.com/sourcegraph/sourcegraph/pull/58539