### PR TITLE
telemetry: add TimestampTelemetryProcessor

### DIFF
--- a/schema/shared.graphql
+++ b/schema/shared.graphql
@@ -12,3 +12,10 @@ type EmptyResponse {
 A valid JSON value.
 """
 scalar JSONValue
+
+"""
+An RFC 3339-encoded UTC date string, such as 1973-11-29T21:33:09Z. This value can be parsed into a
+JavaScript Date using Date.parse. To produce this value from a JavaScript Date instance, use
+Date#toISOString.
+"""
+scalar DateTime

--- a/schema/telemetry.graphql
+++ b/schema/telemetry.graphql
@@ -1,7 +1,29 @@
 """
+Mutations for recording events from clients.
+"""
+type TelemetryMutation {
+  """
+  Record a batch of telemetry events.
+
+  ❗ Do not use this directly when recording events in-product - use the
+  @sourcegraph/telemetry package, or equivalent, instead.
+  """
+  recordEvents(events: [TelemetryEventInput!]!): EmptyResponse
+}
+
+"""
 Properties comprising a telemetry V2 event that can be reported by a client.
 """
 input TelemetryEventInput {
+  """
+  Timestamp at which the time was recorded. If not provided, a timestamp is
+  generated when the server receives the event, but this does not guarantee
+  consistent ordering or accuracy.
+
+  This parameter is only available in Sourcegraph 5.2.5 and later.
+  """
+  timestamp: DateTime
+
   """
   Feature associated with the event in camelCase, e.g. 'myFeature'.
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,6 +12,12 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
+  /**
+   * An RFC 3339-encoded UTC date string, such as 1973-11-29T21:33:09Z. This value can be parsed into a
+   * JavaScript Date using Date.parse. To produce this value from a JavaScript Date instance, use
+   * Date#toISOString.
+   */
+  DateTime: { input: any; output: any; }
   /** A valid JSON value. */
   JSONValue: { input: any; output: any; }
 };
@@ -68,6 +74,14 @@ export type TelemetryEventInput = {
   parameters: TelemetryEventParametersInput;
   /** Information about where this event came from. */
   source: TelemetryEventSourceInput;
+  /**
+   * Timestamp at which the time was recorded. If not provided, a timestamp is
+   * generated when the server receives the event, but this does not guarantee
+   * consistent ordering or accuracy.
+   *
+   * This parameter is only available in Sourcegraph 5.2.5 and later.
+   */
+  timestamp?: InputMaybe<Scalars['DateTime']['input']>;
 };
 
 /**
@@ -146,4 +160,22 @@ export type TelemetryEventSourceInput = {
   client: Scalars['String']['input'];
   /** Version of the source client of the event. */
   clientVersion?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** Mutations for recording events from clients. */
+export type TelemetryMutation = {
+  __typename?: 'TelemetryMutation';
+  /**
+   * Record a batch of telemetry events.
+   *
+   * ❗ Do not use this directly when recording events in-product - use the
+   * @sourcegraph/telemetry package, or equivalent, instead.
+   */
+  recordEvents?: Maybe<EmptyResponse>;
+};
+
+
+/** Mutations for recording events from clients. */
+export type TelemetryMutationRecordEventsArgs = {
+  events: Array<TelemetryEventInput>;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -386,7 +386,7 @@ class EventRecorder<
             version: parameters.version || 0,
             interactionID: parameters.interactionID,
             metadata: parameters.metadata
-              ? Object.entries<number | undefined>(parameters.metadata).map(
+              ? Object.entries(parameters.metadata).map(
                   ([key, value]): TelemetryEventMetadataInput => ({
                     key,
                     value: value || 0,

--- a/src/processors/timestamp.ts
+++ b/src/processors/timestamp.ts
@@ -1,0 +1,29 @@
+import { TelemetryEventInput } from "../api";
+import { TelemetryProcessor } from "../processors";
+
+export interface TimestampProvider {
+  /**
+   * Provide the current timestamp.
+   */
+  now(): Date;
+}
+
+/**
+ * TimestampTelemetryProcessor attaches the current time to events as they are
+ * processed. TelemetryProcessors are applied as soon as
+ * (EventRecorder).recordEvent is called, so the current time is exactly the
+ * time the event was recorded.
+ */
+export class TimestampTelemetryProcessor implements TelemetryProcessor {
+  constructor(
+    private provider: TimestampProvider = { now: () => new Date() }
+  ) {}
+
+  processEvent(event: TelemetryEventInput): void {
+    /**
+     * toISOString() gives us an RFC 3339-encoded UTC date string format, which
+     * is required for `scalar DateTime` input.
+     */
+    event.timestamp = this.provider.now().toISOString();
+  }
+}


### PR DESCRIPTION
Adds support for https://github.com/sourcegraph/sourcegraph/pull/58944 with a processor that can be opted-in to attach the current time to all events, as opposed to letting it happen serverside.