### PR TITLE
remove RxJS to reduce deps and bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,8 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc",
-    "prepublish": "yarn build",
-    "prepack": "yarn prepublish",
+    "build": "tsc -b --clean && tsc -b",
+    "prepublish": "pnpm build",
     "generate": "npx graphql-codegen --config graphql-codegen.yml"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/telemetry",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Sourcegraph client telemetry v2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -8,18 +8,15 @@
     "type": "git",
     "url": "git+https://github.com/sourcegraph/telemetry.git"
   },
-  "dependencies": {
-    "rxjs": "^7.8.1"
-  },
   "devDependencies": {
+    "@graphql-codegen/cli": "^5.0.0",
+    "@graphql-codegen/typescript": "^4.0.1",
     "@sourcegraph/tsconfig": "^4.0.1",
     "@types/jest": "^29.5.4",
     "jest": "^29.6.4",
     "ts-jest": "^29.1.1",
     "typescript": "^4.5.5",
-    "typescript-common": "^1.0.5-beta",
-    "@graphql-codegen/cli": "^5.0.0",
-    "@graphql-codegen/typescript": "^4.0.1"
+    "typescript-common": "^1.0.5-beta"
   },
   "scripts": {
     "test": "jest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,10 +1,5 @@
 lockfileVersion: '6.0'
 
-dependencies:
-  rxjs:
-    specifier: ^7.8.1
-    version: 7.8.1
-
 devDependencies:
   '@graphql-codegen/cli':
     specifier: ^5.0.0
@@ -4067,6 +4062,7 @@ packages:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
       tslib: 2.6.2
+    dev: true
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -4396,6 +4392,7 @@ packages:
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+    dev: true
 
   /type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}

--- a/src/processors/callback.ts
+++ b/src/processors/callback.ts
@@ -1,5 +1,5 @@
-import { TelemetryProcessor } from '.';
-import { TelemetryEventInput } from "../api";
+import type { TelemetryProcessor } from '.';
+import type { TelemetryEventInput } from "../api";
 
 /**
  * CallbackTelemetryProcessor runs callback on all telemetry events. The

--- a/src/processors/timestamp.ts
+++ b/src/processors/timestamp.ts
@@ -1,5 +1,5 @@
-import { TelemetryEventInput } from "../api";
-import { TelemetryProcessor } from ".";
+import type { TelemetryProcessor } from ".";
+import type { TelemetryEventInput } from "../api";
 
 export interface TimestampProvider {
   /**


### PR DESCRIPTION
Reduces bundle size of all applications using `@sourcegraph/telemetry` by ~580kB.